### PR TITLE
build: de psycopg2 para seu respectivo binário

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Django==5.2
 sqlparse==0.5.3
 tzdata==2025.2
 python-decouple==3.8
-psycopg2==2.9.10
+psycopg2-binary==2.9.10


### PR DESCRIPTION
Ao instalar as dependências com 'pip install -r requirements.txt', ao chegar na dependência de psycopg dava o seguinte erro:

````txt
> Getting requirements to build wheel did not run successfully
````

Modifiquei para o binário e funcionou normalmente.