### PR TITLE
build: secret key agora lê do .env

### DIFF
--- a/capital_nexus/settings.py
+++ b/capital_nexus/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-hvi)&%57r*zw@z(at31$bz%sw)e_4ek&li5i+-d&-io)th5uxr'
+SECRET_KEY = config("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Django==5.2
 sqlparse==0.5.3
 tzdata==2025.2
 python-decouple==3.8
-psycopg2==2.9.10
+psycopg2-binary==2.9.10


### PR DESCRIPTION
Ao instalar as dependências com 'pip install -r requirements.txt', chegando na dependência de psycopg dava o seguinte erro:

````txt
> Getting requirements to build wheel did not run successfully
````

Modifiquei para o binário e também adicionei a secret key ao .env para não ficar exposta.