### PR TITLE
docs(contribuição): adiciona CONTRIBUTING.md ao git-pages e corrige paths

### DIFF
--- a/docs/visao/contribuicao.md
+++ b/docs/visao/contribuicao.md
@@ -1,0 +1,134 @@
+# 🛠️ Guia de Contribuição
+
+Para manter a organização e a qualidade do código, siga estas diretrizes.
+
+---
+
+## ✅ Commits
+
+Utilizamos o padrão [Conventional Commits](https://www.conventionalcommits.org/).  
+Formato:
+```
+<tipo>(escopo): descrição breve
+```
+
+### Tipos válidos:
+
+- `feat`: nova funcionalidade
+- `fix`: correção de bugs
+- `docs`: documentação
+- `style`: formatação e estilo (sem alteração de código)
+- `refactor`: refatoração sem mudança de comportamento
+- `perf`: melhoria de performance
+- `test`: testes adicionados ou atualizados
+- `build`: mudanças que afetam o processo de build ou dependências
+- `ci`: configuração de integração contínua
+- `chore`: tarefas administrativas ou manutenção
+- `revert`: desfaz alterações anteriores
+
+### Exemplo:
+```
+feat(auth): implementa login com autenticação JWT
+```
+
+---
+
+## 🌱 Nome de branch
+
+Use o padrão:
+```
+<tipo>/<descricao-curta>
+```
+
+### Exemplos:
+- `feat/cadastro-usuario`
+- `fix/erro-listagem-produtos`
+- `docs/adiciona-readme`
+- `refactor/reorganiza-componentes`
+
+---
+
+## 🚀 Pull Request
+
+Antes de abrir um PR, verifique:
+
+```
+- [ ] A branch está atualizada com a `main` ou `develop`
+- [ ] Os commits seguem o padrão
+- [ ] O código foi testado localmente
+- [ ] A documentação (se aplicável) foi atualizada
+- [ ] Nenhum arquivo sensível ou desnecessário foi incluído
+```
+
+### 📝 Título do PR
+
+Mesmo padrão do commit:
+```
+<tipo>(escopo): descrição breve
+```
+
+**Exemplo:**
+```
+feat(auth): implementa login com autenticação JWT
+```
+
+### 💬 Corpo do PR
+
+Inclua:
+- O que foi feito
+- Por que foi feito
+- Como testar
+- Pendências (se houver)
+- Screenshot ou vídeo (se aplicável)
+
+---
+
+## 🔁 Exemplo completo
+
+- Nome da branch:
+  ```
+  feat/pagina-login
+  ```
+
+- Commits:
+  ```
+  feat(login): cria layout da página de login
+  feat(login): integra login com backend usando JWT
+  ```
+
+- Título do Pull Request:
+  ```
+  feat(login): implementa login funcional com autenticação JWT
+  ```
+
+- Corpo do Pull Request:
+    ```markdown
+    ## O que foi feito
+    - Página de login com campos de email e senha
+    - Integração com backend usando JWT
+    - Armazenamento do token no localStorage
+
+    ## Por que
+    Esta funcionalidade é necessária para autenticar usuários e proteger rotas privadas.
+
+    ## Como testar
+    - Rodar o backend local
+    - Acessar `/login` no frontend
+    - Inserir credenciais válidas
+    - Verificar se o token é salvo e se redireciona para `/dashboard`
+
+    ## Pendências
+    - Testes automatizados ainda não implementados
+    ```
+
+---
+
+## 💬 Dúvidas?
+
+Abra uma *issue* ou entre em contato com um dos mantenedores do projeto.
+
+
+## Histórico de versão 
+|**Data**|**Versão** |**Descrição** |**Autor**|
+| :- | :- | :- | :- |
+| **21/05/25** | 1.0 | Adiciona documento de política de contribuição ao git pages | Sophia e Christopher|

--- a/docs/visao/doredod.md
+++ b/docs/visao/doredod.md
@@ -28,10 +28,11 @@ O DoD define os critérios que precisam ser cumpridos para que uma funcionalidad
 1. Contempla critérios de aceite estabelecidos?
 1. Está documentado para uso?
 1. Foi revisado por outro desenvolvedor?
-1. Segue os padrões [estabelecidos de codificação](../../CONTRIBUTING.md)?
+1. Segue os padrões [estabelecidos de codificação](../contribuicao)?
 1. Foi testado?
 
 ## Histórico de versão 
 |**Data**|**Versão** |**Descrição** |**Autor**|
 | :- | :- | :- | :- |
-| 13/05/2025 | 0.1 | Definindo DoR, DoD e critérios de aceite | Wanjo Christopher |
+| **13/05/2025** | 0.1 | Definindo DoR, DoD e critérios de aceite | Wanjo Christopher |
+| **21/05/2025** | 0.1 | Corrige caminho do documento de contribuição | Wanjo Christopher |

--- a/docs/visao/engrequisitos.md
+++ b/docs/visao/engrequisitos.md
@@ -33,7 +33,7 @@ A Engenharia de Requisitos dispõe de diversas **técnicas e práticas**, que de
     1. Contempla critérios de aceite estabelecidos?
     1. Está documentado para uso?
     1. Foi revisado por outro desenvolvedor?
-    1. Segue os padrões [estabelecidos de codificação](../../CONTRIBUTING.md)?
+    1. Segue os padrões [estabelecidos de codificação](..\contribuicao)?
     1. Foi testado?
 - **Revisão em Pares**: A revisão em pares entre os membros do grupo auxiliará na **verificação dos requisitos**, verificando se estão sendo feitos de maneira correta.
 
@@ -75,6 +75,7 @@ O Processo do AUP (Agiled Unified Process) adota uma **filosofia pragmática e �
 ## Histórico de versão 
 |**Data**|**Versão** |**Descrição** |**Autor**|
 | :- | :- | :- | :- |
-| 12/05/2025 | 0.1 | Descrição das técnicas utilizadas | Wanjo Christopher |
-| 12/05/2025 | 0.2 | Correlação entre técnicas e fases do AUP | Wanjo Christopher|
-| 13/05/2025 | 0.3 | Atualizando DoR e DoD | Wanjo Christopher|
+| **12/05/2025** | 0.1 | Descrição das técnicas utilizadas | Wanjo Christopher |
+| **12/05/2025** | 0.2 | Correlação entre técnicas e fases do AUP | Wanjo Christopher|
+| **13/05/2025** | 0.3 | Atualizando DoR e DoD | Wanjo Christopher|
+| **21/05/2025** | 0.1 | Corrige caminho do documento de contribuição | Wanjo Christopher |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
       - Interação entre equipe e cliente: visao/interacao.md
       - DoR e DoD: visao/doredod.md
       - Lições aprendidas: visao/licoes.md
+      - Política de Contribuição: visao/contribuicao.md
       - Referências: visao/referencias.md 
   - Requisitos:
       - Requisitos funcionais: requisitos/reqfuncional.md
@@ -37,6 +38,9 @@ theme:
     - navigation.instant
     - navigation.top
     - navigation.tracking
+    - content.code.select
+    - content.code.copy
+
 
   palette:
     - scheme: default
@@ -59,3 +63,12 @@ theme:
 
 extra_css:
   - stylesheets/styles.css
+
+markdown_extensions:
+- pymdownx.highlight:
+    anchor_linenums: true
+    line_spans: __span
+    pygments_lang_class: true
+- pymdownx.inlinehilite
+- pymdownx.snippets
+- pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ nav:
       - Interação entre equipe e cliente: visao/interacao.md
       - DoR e DoD: visao/doredod.md
       - Lições aprendidas: visao/licoes.md
-      - Política de Contribuição: visao/contribuicao.md
+      - Política de contribuição: visao/contribuicao.md
       - Referências: visao/referencias.md 
   - Requisitos:
       - Requisitos funcionais: requisitos/reqfuncional.md


### PR DESCRIPTION
## 📝 Descrição

Adiciona o documento de contribuição ao git-pages e extensão para exibir códigos no mkdocs. Corrige paths.


## 🔍 Alterações Realizadas

- Adição do documento de contribuição
- Adição de extensão para exibir códigos no mkdocs corretamente
- Corrige os paths do arquivo de contribuição

## ✅ Checklist

- [x] O código foi testado localmente
- [x] As alterações estão de acordo com o padrão de codificação do projeto
- [x] Não quebrei nenhuma funcionalidade existente
- [ ] Incluí testes (se aplicável)
- [x] Atualizei a documentação (se necessário)

## 🧪 Como Testar

1. Instale o mkdocs-material
2. Rode ``mkdocs serve``
3. Verifique as mudanças no seu localhost
